### PR TITLE
[String Update] Rename "Approve" to "Connect"

### DIFF
--- a/src/components/Body/index.tsx
+++ b/src/components/Body/index.tsx
@@ -594,7 +594,7 @@ function Body() {
             {!isConnected && (
               <Box pt={6}>
                 <Button onClick={approveSession} mr={10}>
-                  Approve ✔
+                  Connect ✔
                 </Button>
                 <Button onClick={rejectSession}>Reject ❌</Button>
               </Box>


### PR DESCRIPTION
`Approve` sort of suggests you're about to make a transaction (eg approve a smart contract to operate your ERC721/ERC20). But really the action is just connecting the impersonating account to a website. So I'm proposing renaming it to `Connect` since that's consistent with how other wallet apps (eg metamask, rainbow) handle this part.

FYI hope it's not weird that I'm making two of these in-a-row out of nowhere :). I don't expect to have any more. I'm doing this because I appreciate your project, because I want to contribute to open source projects, and because I'm hoping I can leverage impersonator to make the user experience for my smart contract + web app, [Flashmint](https://twitter.com/therealjfrantz/status/1488187274886062083) cleaner. Cheers