### PR TITLE
Add localhost support

### DIFF
--- a/src/components/Body/networkInfo.ts
+++ b/src/components/Body/networkInfo.ts
@@ -47,6 +47,10 @@ const networkInfo = [
     chainID: 5,
     name: "Goerli Testnet",
   },
+  {
+    chainID: 1337,
+    name: "Localhost 8545",
+  },
 ];
 
 export default networkInfo;


### PR DESCRIPTION
Using an account impersonation feature (like [`ganache-cli --unlock`](https://docs.nethereum.com/en/latest/ethereum-and-clients/ganache-cli/#command-line) or [`hardhat_impersonateAccount`](https://hardhat.org/hardhat-network/docs/reference#hardhat_impersonateaccount)) on a network fork in conjunction w/ Impersonator allows you to interact with dapps as if you were another user

This is helpful for debugging issues specific to an account which is not owned by you.

This PR simply adds another network to the network configs to support this flow